### PR TITLE
Refactor documentation: Add auto-build/counter tabs feature, translat…

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,133 @@
+# LoL Viewer - Development Guide
+
+## Debug Logging
+
+**Log files are only created when the executable name contains `debug`.**
+
+Examples:
+- `lol-viewer-debug.exe` → Logs enabled ✓
+- `lol-viewer.exe` → No logs
+- `python main.py` → Logs enabled ✓ (during development)
+
+The log file (`lol_viewer_debug.log`) records:
+- Champion data loading status
+- Autocomplete configuration status
+- Application initialization process
+
+### How to Check Logs
+
+1. Launch the application
+2. Enter text in the champion name input field
+3. Open `lol_viewer_debug.log` in the same folder as the application
+
+### Troubleshooting
+
+**If autocomplete is not working, check the following in the logs:**
+
+1. **Is data loaded?**
+   - Does the log show `Loaded 171 champions`?
+   - If not → Verify that `champions.json` exists in the same folder as the executable
+
+2. **Is autocomplete configured?**
+   - Does the log show `Populated model with 171 champions`?
+   - If not → Champion data loading may have failed
+
+3. **Are there any Qt-related errors?**
+   - Check if any error messages are recorded
+
+## Development Setup
+
+### Required Packages
+
+```bash
+pip install -r requirements.txt
+```
+
+### Updating Champion Data
+
+```bash
+python fetch_champions.py
+```
+
+### Running Tests
+
+```bash
+python test_champion_data_basic.py
+python test_autocomplete.py
+```
+
+### Running the Application
+
+```bash
+python main.py
+```
+
+## Building
+
+`champions.json` is embedded into the executable, so no separate deployment is needed.
+
+### Pre-Build Verification (Important!)
+
+Before building, verify that all required files are present:
+
+```bash
+python check_build.py
+```
+
+Confirm that all items show ✓ before proceeding with the build.
+
+### Recommended Build Method
+
+**Run from the project folder:**
+
+**Debug Version (with logging):**
+```bash
+# Clean build (recommended)
+python clean_build.py
+pyinstaller lol-viewer-debug.spec
+
+# Or direct build
+pyinstaller lol-viewer-debug.spec
+```
+
+**Release Version (no logging):**
+```bash
+# Clean build (recommended)
+python clean_build.py
+pyinstaller lol-viewer.spec
+
+# Or direct build
+pyinstaller lol-viewer.spec
+```
+
+**Note:** After modifying `.spec` files, it's recommended to clear the cache with `python clean_build.py` before rebuilding.
+
+### Manual Build
+
+#### For Windows
+
+**Debug Version:**
+```bash
+pyinstaller --onefile --windowed --name lol-viewer-debug --add-data "champions.json;." main.py
+```
+
+**Release Version:**
+```bash
+pyinstaller --onefile --windowed --name lol-viewer --add-data "champions.json;." main.py
+```
+
+#### For macOS/Linux
+
+**Debug Version:**
+```bash
+pyinstaller --onefile --windowed --name lol-viewer-debug --add-data "champions.json:." main.py
+```
+
+**Release Version:**
+```bash
+pyinstaller --onefile --windowed --name lol-viewer --add-data "champions.json:." main.py
+```
+
+### After Building
+
+The executable will be created in the `dist` folder and can be run standalone.

--- a/README.md
+++ b/README.md
@@ -1,143 +1,43 @@
 # LoL Viewer
 
-League of Legendsのチャンピオン情報をLoLAnalyticsで簡単に閲覧できるアプリケーション。
+A desktop application for easily viewing League of Legends champion information with LoLAnalytics.
 
-## 機能
+## Features
 
-- チャンピオン名の入力でビルド/カウンター情報を表示
-- 英語名・日本語名両方に対応したオートコンプリート
-- サムネイル画像付きの候補リスト
-- 複数のWebViewを同時に開いて比較可能
-- ダークテーマUI
+- **Champion Search**: Display build/counter information by entering champion names
+- **Bilingual Autocomplete**: Supports both English and Japanese champion names
+- **Visual Search**: Candidate list with champion thumbnail images
+- **Multiple Tabs**: Open and compare multiple WebViews simultaneously
+- **Dark Theme UI**: Easy on the eyes interface
+- **Live Game Detection**: Automatically detects your live game and shows champion information
+- **Lane Selection**: Choose your lane role for accurate champion recommendations
+- **Auto Build/Counter Tabs**: During online matches, automatically opens Build tabs for your picked champions and Counter tabs for opponent picked champions
 
-## デバッグログ
+## How to Use
 
-**実行ファイル名に `debug` が含まれる場合のみ**ログファイルが出力されます。
+1. Launch the application
+2. Enter a champion name in the search field (English or Japanese)
+3. Select "Build" or "Counter" tab to view information
+4. Use the "Live Game" tab to automatically detect ongoing matches
 
-例：
-- `lol-viewer-debug.exe` → ログ出力 ✓
-- `lol-viewer.exe` → ログ出力なし
-- `python main.py` → ログ出力 ✓（開発時）
+### Live Game Features
 
-ログファイル（`lol_viewer_debug.log`）には以下の情報が記録されます：
-- チャンピオンデータの読み込み状況
-- オートコンプリートの設定状況
-- アプリケーションの初期化過程
+- Automatically detects when you're in an active League of Legends game
+- Displays your team's champions and the enemy team's champions
+- Select your lane to get personalized champion recommendations
+- **Auto-open tabs**: When champions are picked:
+  - Your picked champions → Build tabs automatically open
+  - Enemy picked champions → Counter tabs automatically open
+- Refresh button to update game status
 
-### ログの確認方法
+## Download
 
-1. アプリケーションを起動
-2. チャンピオン名入力欄に文字を入力
-3. アプリケーションと同じフォルダの `lol_viewer_debug.log` を開く
+Download the latest version from the [Releases](../../releases) page.
 
-### トラブルシューティング
+## Development
 
-**オートコンプリートが表示されない場合、ログで以下を確認：**
+For development instructions, debug logging, and build information, please see [DEV.md](DEV.md).
 
-1. **データが読み込まれているか**
-   - ログに `Loaded 171 champions` と表示されているか
-   - 表示されていない場合 → `champions.json` が実行ファイルと同じフォルダにあるか確認
+## License
 
-2. **オートコンプリートが設定されているか**
-   - ログに `Populated model with 171 champions` と表示されているか
-   - 表示されていない場合 → チャンピオンデータの読み込みに失敗している可能性
-
-3. **Qt関連のエラーがないか**
-   - エラーメッセージが記録されていないか確認
-
-## 開発
-
-### 必要なパッケージ
-
-```bash
-pip install -r requirements.txt
-```
-
-### チャンピオンデータの更新
-
-```bash
-python fetch_champions.py
-```
-
-### テストの実行
-
-```bash
-python test_champion_data_basic.py
-python test_autocomplete.py
-```
-
-### アプリケーションの実行
-
-```bash
-python main.py
-```
-
-## ビルド
-
-`champions.json`は実行ファイルに埋め込まれるため、別途配置不要です。
-
-### ビルド前の確認（重要！）
-
-ビルドする前に、必要なファイルが揃っているか確認：
-
-```bash
-python check_build.py
-```
-
-すべて✓であることを確認してからビルドしてください。
-
-### 簡単な方法（推奨）
-
-**プロジェクトフォルダで**実行してください：
-
-**デバッグ版（ログ出力あり）:**
-```bash
-# クリーンビルド（推奨）
-python clean_build.py
-pyinstaller lol-viewer-debug.spec
-
-# または直接ビルド
-pyinstaller lol-viewer-debug.spec
-```
-
-**リリース版（ログ出力なし）:**
-```bash
-# クリーンビルド（推奨）
-python clean_build.py
-pyinstaller lol-viewer.spec
-
-# または直接ビルド
-pyinstaller lol-viewer.spec
-```
-
-**注意:** `.spec`ファイルを変更した後は、`python clean_build.py`でキャッシュをクリアしてから再ビルドすることを推奨します。
-
-### 手動ビルド
-
-#### Windowsの場合
-
-**デバッグ版:**
-```bash
-pyinstaller --onefile --windowed --name lol-viewer-debug --add-data "champions.json;." main.py
-```
-
-**リリース版:**
-```bash
-pyinstaller --onefile --windowed --name lol-viewer --add-data "champions.json;." main.py
-```
-
-#### macOS/Linuxの場合
-
-**デバッグ版:**
-```bash
-pyinstaller --onefile --windowed --name lol-viewer-debug --add-data "champions.json:." main.py
-```
-
-**リリース版:**
-```bash
-pyinstaller --onefile --windowed --name lol-viewer --add-data "champions.json:." main.py
-```
-
-### ビルド後
-
-`dist` フォルダに実行ファイルが生成されます。単体で実行可能です。
+This project is provided as-is for personal use.


### PR DESCRIPTION
…e to English, and separate dev docs

- Add feature description for automatic Build/Counter tab opening during live games
- Translate all documentation from Japanese to English
- Move development-related content (debug logs, build instructions) to separate DEV.md
- Improve README structure with clearer feature descriptions and usage guide