### PR TITLE
fix: analyze full commit messages including PR body for squash merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
             echo "type=${{ github.event.inputs.version_type }}" >> $GITHUB_OUTPUT
             echo "Manual version bump: ${{ github.event.inputs.version_type }}"
           else
-            # Automatic detection from commit messages
-            COMMITS=$(git log --format=%s $(git describe --tags --abbrev=0 2>/dev/null || echo "")..HEAD 2>/dev/null || git log --format=%s)
+            # Automatic detection from commit messages (including PR body for squash merges)
+            COMMITS=$(git log --format=%B $(git describe --tags --abbrev=0 2>/dev/null || echo "")..HEAD 2>/dev/null || git log --format=%B)
 
             echo "Analyzing commits:"
             echo "$COMMITS"


### PR DESCRIPTION
Changed from --format=%s (subject only) to --format=%B (full message) to properly detect feat: commits in squash-merged PRs.

This fixes the issue where release.yml couldn't detect feature commits because squash merge includes individual commit messages in the body, not the subject line.