### PR TITLE
fix: ensure latest version is available via nightly.link after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload as Artifact for nightly.link
+        uses: actions/upload-artifact@v4
+        with:
+          name: lol-viewer-setup
+          path: installer_output/lol-viewer-setup.exe
+          retention-days: 90
+
       - name: Build Summary
         run: |
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/updater.py
+++ b/updater.py
@@ -22,7 +22,8 @@ class Updater:
     GITHUB_REPO = "kc7891/lol-viewer"
     GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
     # Use nightly.link for faster downloads (especially from Asia)
-    NIGHTLY_LINK_URL = "https://nightly.link/kc7891/lol-viewer/workflows/nightly-build/main/lol-viewer-setup.zip"
+    # References the release workflow which runs on every release
+    NIGHTLY_LINK_URL = "https://nightly.link/kc7891/lol-viewer/workflows/release/main/lol-viewer-setup.zip"
 
     def __init__(self, current_version: str, parent_widget=None):
         """


### PR DESCRIPTION
- Add artifact upload to release.yml workflow
- Upload same exe as artifact for nightly.link distribution
- Change updater.py to reference 'release' workflow instead of 'nightly-build'
- Ensures version bump is immediately reflected in auto-updater
- Fixes issue where old version was distributed after new release