### PR TITLE
fix: return release_data even when up-to-date to prevent false error …

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -70,7 +70,7 @@ class Updater:
                 return True, release_data
             else:
                 logger.info(f"✓ Application is up to date (current: {self.current_version}, latest: {latest_version})")
-                return False, None
+                return False, release_data  # Return release_data even when up-to-date
 
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to check for updates: {e}")


### PR DESCRIPTION
…message

- Previously returned None when app was up-to-date
- Caused settings screen to show 'Could not connect to update server'
- Now correctly returns release_data in both cases
- Settings will show 'You have the latest version' correctly