### PR TITLE
Fix installation path not persisting between updates

### DIFF
--- a/lol-viewer.iss
+++ b/lol-viewer.iss
@@ -62,3 +62,20 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}"
+
+[Registry]
+; Save installation path to registry for persistence across updates
+Root: HKCU; Subkey: "Software\{#MyAppPublisher}\{#MyAppName}"; ValueType: string; ValueName: "InstallPath"; ValueData: "{app}"; Flags: uninsdeletekey
+
+[Code]
+// Read previous installation path from registry and set as default
+procedure InitializeWizard();
+var
+  PrevPath: String;
+begin
+  if RegQueryStringValue(HKEY_CURRENT_USER, 'Software\{#MyAppPublisher}\{#MyAppName}', 'InstallPath', PrevPath) then
+  begin
+    if DirExists(PrevPath) then
+      WizardForm.DirEdit.Text := PrevPath;
+  end;
+end;


### PR DESCRIPTION
InnoSetupスクリプトに以下の設定を追加:
- UsePreviousDir=yes: 前回のインストールディレクトリを使用
- InstallDirRegKey: インストールパスをレジストリに保存

これにより、アップデート時に前回と同じインストール先が
デフォルトで選択されるようになります。