### PR TITLE
Fix Vanguard and client crash on app update

### DIFF
--- a/lol-viewer.iss
+++ b/lol-viewer.iss
@@ -32,7 +32,9 @@ ArchitecturesInstallIn64BitMode=x64
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
 ; Silent install support
-CloseApplications=yes
+; CloseApplications=no to prevent Vanguard from crashing when updating
+; The updater.py checks for running League/Vanguard processes before applying updates
+CloseApplications=no
 ; Note: App restart is handled by [Run] section (postinstall without skipifsilent)
 ; RestartApplications is not used to prevent duplicate launches
 ; Automatically use the language from previous installation

--- a/updater.py
+++ b/updater.py
@@ -324,13 +324,12 @@ class Updater:
             )
 
             # Build installer arguments
-            # /CLOSEAPPLICATIONS = Automatically close running instances
             # /NORESTART = Don't restart Windows
             # /DIR="path" = Preserve installation directory
             # Note: Language is automatically preserved via UsePreviousLanguage=yes in .iss
+            # Note: /CLOSEAPPLICATIONS is NOT used to prevent Vanguard from crashing
             installer_args = [
                 setup_exe_path,
-                '/CLOSEAPPLICATIONS',
                 '/NORESTART'
             ]
 


### PR DESCRIPTION
- /CLOSEAPPLICATIONSフラグを削除（強制終了を防止）
- Inno SetupのCloseApplications設定をnoに変更