### PR TITLE
Tab auto-open regression

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -83,7 +83,7 @@ class TestChampionViewerWidget:
     def test_widget_display_name(self, qapp, champion_data):
         """Test widget display name"""
         widget = ChampionViewerWidget(0, champion_data)
-        assert widget.get_display_name() == "View #1"
+        assert widget.get_display_name() == "(Empty)"
         widget.current_champion = "ashe"
         # When a champion is set, prefer the champion name over internal viewer numbering.
         assert widget.get_display_name() == "Ashe"


### PR DESCRIPTION
Fixes regressions in tab naming and auto-opening behavior for Pick/Counter viewers.

Commit `4f064fd` introduced a regression where `get_display_name()` always prepended "View #n" to tab labels, even when champion context was available. This PR reverts that behavior to prioritize champion names. Additionally, auto-opening of Pick/Counter tabs was not consistently focusing the correct UI elements or ensuring visibility, leading to a "not opening" user experience, which is now addressed by explicitly focusing the Viewers screen and ensuring enemy counter tabs are not hidden by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d0ac60d-28e1-4d33-9f34-f4d26396f893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d0ac60d-28e1-4d33-9f34-f4d26396f893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

