### PR TITLE
Update confirmation logic issue

### DIFF
--- a/test_updater.py
+++ b/test_updater.py
@@ -40,7 +40,9 @@ class TestUpdater:
             has_update, release_info = updater.check_for_updates()
 
         assert has_update is False
-        assert release_info is None
+        # Successful check should still return release info (used by UI to show latest version)
+        assert release_info is not None
+        assert release_info['tag_name'] == 'v1.0.0'
 
     def test_version_comparison_older_remote(self):
         """Test that older remote version is not treated as update"""
@@ -56,7 +58,9 @@ class TestUpdater:
             has_update, release_info = updater.check_for_updates()
 
         assert has_update is False
-        assert release_info is None
+        # Successful check should still return release info (used by UI to show latest version)
+        assert release_info is not None
+        assert release_info['tag_name'] == 'v1.5.0'
 
     def test_network_error_handling(self):
         """Test that network errors are handled gracefully"""

--- a/updater.py
+++ b/updater.py
@@ -45,14 +45,14 @@ class Updater:
         self.current_version = current_version
         self.parent_widget = parent_widget
 
-    def check_for_updates(self) -> tuple[bool, dict]:
+    def check_for_updates(self) -> tuple[bool, dict | None]:
         """
         Check if a new version is available
 
         Returns:
             Tuple of (has_update, release_info)
             - has_update: True if new version available
-            - release_info: Dict with release information or None
+            - release_info: Dict with release information when check succeeds; None on failure
         """
         try:
             logger.info(f"Checking for updates (current version: {self.current_version})")
@@ -79,7 +79,9 @@ class Updater:
                 return True, release_data
             else:
                 logger.info(f"✓ Application is up to date (current: {self.current_version}, latest: {latest_version})")
-                return False, None
+                # Important: returning None here makes callers unable to distinguish
+                # "up to date" from "failed to check". Return release data on success.
+                return False, release_data
 
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to check for updates: {e}")


### PR DESCRIPTION
Fix update check logic to correctly report "up to date" instead of "connection error".

The `Updater.check_for_updates()` method was returning `None` for `release_info` when the application was already at the latest version. This caused the UI to misinterpret it as a "failed to connect to update server" error, instead of "You have the latest version". Now, `release_info` is always returned on a successful check, allowing the UI to display the correct status.

---
<a href="https://cursor.com/background-agent?bcId=bc-80c3c759-3eba-4891-9cf7-9843541aa7dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80c3c759-3eba-4891-9cf7-9843541aa7dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

