### PR TITLE
Core files gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ installer_output/
 Thumbs.db
 desktop.ini
 
+# Core dumps
+core
+core.*
+*.core
+
 # Package directory
 package/
 


### PR DESCRIPTION
Add core dump patterns to `.gitignore` to prevent tracking of core files.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b587cf5-a660-489a-9bdd-acadf9edc0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b587cf5-a660-489a-9bdd-acadf9edc0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

