### PR TITLE
Installer path issue investigation

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -369,7 +369,12 @@ start "" "{current_exe_path}"
             # Add installation directory if available
             # Use quotes to handle paths with spaces (e.g., "C:\Program Files\LoL Viewer")
             if install_dir:
-                installer_args.append(f'/DIR="{install_dir}"')
+                # IMPORTANT (Windows): When passing a list of args to subprocess, Python will add
+                # quoting as needed. If we embed quotes inside the /DIR value, the installer may
+                # receive them literally and treat the path as relative, which can lead to a
+                # duplicated drive prefix like "D:\D:\Program Files\...".
+                install_dir = install_dir.strip('"')
+                installer_args.append(f'/DIR={install_dir}')
                 logger.info(f"Preserving installation directory: {install_dir}")
 
             logger.info(f"Launching installer with args: {installer_args}")


### PR DESCRIPTION
Fixes duplicated drive letter in installer's default path by removing redundant quotes from the `/DIR` argument passed to Inno Setup.

The previous implementation passed `/DIR="<path>"` as an argument in a list to `subprocess`. This resulted in double quoting by Windows, causing Inno Setup to misinterpret the path as relative and prepend the current drive letter, leading to `D:\D:\Program Files\...`. This change ensures Python's `subprocess` correctly handles quoting for paths with spaces without internal redundant quotes.

---
<a href="https://cursor.com/background-agent?bcId=bc-eba96e5f-4b0c-483a-95ff-476d190e8644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eba96e5f-4b0c-483a-95ff-476d190e8644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

