### PR TITLE
Viewer default tab count

### DIFF
--- a/main.py
+++ b/main.py
@@ -1080,10 +1080,7 @@ class MainWindow(QMainWindow):
 
         viewers_layout.addWidget(self.viewers_splitter)
 
-        # Create initial viewers (default 2) if none exist yet
-        if len(self.viewers) == 0:
-            self.add_viewer()
-            self.add_viewer()
+        # Do not auto-create viewers on launch (default 0).
 
         # Start champion detection service (disabled in tests/headless if needed)
         if _lcu_service_disabled():

--- a/test_main.py
+++ b/test_main.py
@@ -156,10 +156,9 @@ class TestMainWindow:
         assert window.champion_data is not None
 
     def test_main_window_has_initial_viewers(self, qapp):
-        """Test main window has initial 2 viewers"""
+        """Test main window has no viewers by default"""
         window = MainWindow()
-        assert len(window.viewers) == 2
-        assert all(isinstance(v, ChampionViewerWidget) for v in window.viewers)
+        assert len(window.viewers) == 0
 
     def test_main_window_size(self, qapp):
         """Test main window has correct initial size"""
@@ -177,6 +176,7 @@ class TestMainWindow:
     def test_close_viewer(self, qapp):
         """Test closing a viewer"""
         window = MainWindow()
+        window.add_viewer()
         initial_count = len(window.viewers)
         viewer_to_close = window.viewers[0]
         window.close_viewer(viewer_to_close)
@@ -185,6 +185,7 @@ class TestMainWindow:
     def test_hide_viewer(self, qapp):
         """Test hiding a viewer"""
         window = MainWindow()
+        window.add_viewer()
         viewer_to_hide = window.viewers[0]
         window.hide_viewer(viewer_to_hide)
         assert viewer_to_hide in window.hidden_viewers
@@ -193,9 +194,10 @@ class TestMainWindow:
     def test_update_viewers_list(self, qapp):
         """Test updating viewers list in sidebar"""
         window = MainWindow()
-        assert window.viewers_list.count() == 2
+        window.update_viewers_list()
+        assert window.viewers_list.count() == 0
         window.add_viewer()
-        assert window.viewers_list.count() == 3
+        assert window.viewers_list.count() == 1
 
     def test_close_all_viewers(self, qapp):
         """Test closing all viewers"""
@@ -226,8 +228,9 @@ class TestOpponentChampionInput:
         window.feature_flags["matchup_build"] = True
 
         # Provide at least one "open" champion suggestion from another viewer.
-        if window.viewers:
-            window.viewers[0].current_champion = "ashe"
+        seed = window.add_viewer()
+        assert seed is not None
+        seed.current_champion = "ashe"
 
         viewer = ChampionViewerWidget(999, champion_data, main_window=window)
         qtbot.addWidget(viewer)


### PR DESCRIPTION
Set the default number of viewer tabs to zero at startup.

The application previously opened two viewer tabs by default. This change removes the automatic creation of these initial tabs, resulting in a cleaner startup experience with no viewers open until explicitly added by the user, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-23b3d6a3-f6dd-4853-99d0-ed79b0361850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23b3d6a3-f6dd-4853-99d0-ed79b0361850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

