### PR TITLE
Sidebar viewer close icon

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,6 +29,10 @@ DEFAULT_MATCHUP_URL = (
 DEFAULT_ARAM_URL = "https://u.gg/lol/champions/aram/{name}-aram"
 DEFAULT_LIVE_GAME_URL = "https://u.gg/lol/lg-splash"
 
+# UI glyphs
+# Keep these consistent across the app to avoid subtle visual mismatches.
+CLOSE_BUTTON_GLYPH = "×"
+
 # Feature flags (toggle in Settings page).
 # Add new flags here when introducing gated behavior.
 # NOTE: Keys are persisted via QSettings at "feature_flags/<key>".
@@ -266,7 +270,7 @@ class ViewerListItemWidget(QWidget):
         layout.addWidget(self.visibility_button)
 
         # Close button (placed second)
-        self.close_button = QPushButton("✕")
+        self.close_button = QPushButton(CLOSE_BUTTON_GLYPH)
         self.close_button.setToolTip("Close viewer")
         self.close_button.setStyleSheet("""
             QPushButton {
@@ -401,7 +405,7 @@ class ChampionViewerWidget(QWidget):
         header_layout.addWidget(self.hide_button)
 
         # Close button
-        self.close_button = QPushButton("×")
+        self.close_button = QPushButton(CLOSE_BUTTON_GLYPH)
         self.close_button.setToolTip("Close this viewer")
         self.close_button.setStyleSheet("""
             QPushButton {


### PR DESCRIPTION
Unify the close button glyph across the application to ensure visual consistency.

The left sidebar viewer close button and the main viewer window close button were using different Unicode characters (`✕` and `×`). This PR unifies them to `×` and introduces a `CLOSE_BUTTON_GLYPH` constant to prevent future visual mismatches.

---
<a href="https://cursor.com/background-agent?bcId=bc-55b88588-4d59-4631-8b55-4b3a40f28489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55b88588-4d59-4631-8b55-4b3a40f28489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

