### PR TITLE
Matchup build standard feature

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -220,12 +220,11 @@ class TestMainWindow:
 
 
 class TestOpponentChampionInput:
-    """Regression tests for opponent input (matchup_build feature)."""
+    """Regression tests for opponent champion input (standard feature)."""
 
     def test_opponent_context_suggestions_on_click_and_select(self, qapp, qtbot, champion_data):
         """Clicking an empty opponent field swaps completer to context suggestions safely."""
         window = MainWindow()
-        window.feature_flags["matchup_build"] = True
 
         # Provide at least one "open" champion suggestion from another viewer.
         seed = window.add_viewer()
@@ -258,7 +257,6 @@ class TestOpponentChampionInput:
     def test_opponent_completer_inserts_champion_id(self, qapp, qtbot, champion_data):
         """Opponent field uses the same ChampionCompleter behavior as Champion Name."""
         window = MainWindow()
-        window.feature_flags["matchup_build"] = True
 
         viewer = ChampionViewerWidget(1000, champion_data, main_window=window)
         qtbot.addWidget(viewer)

--- a/test_matchup_features.py
+++ b/test_matchup_features.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-"""Tests for matchup-specific functionality (FeatureFlag-gated in UI).
+"""Tests for matchup-specific functionality.
 
-These tests validate the helper methods/constants that are safe to keep even when
-`matchup_build` is OFF.
+These tests validate helper methods/constants used by the matchup (vs) build flow.
 """
 
 import os


### PR DESCRIPTION
Promotes the "matchup build (vs) input" functionality to a standard, always-on feature and removes its associated feature flag.

This change makes the opponent champion input field, the ability to open matchup (vs) build URLs, and the Matchup URL setting in the Analytics URLs section permanently available, as requested by the user. The "Feature Flags" section in settings is now hidden since no flags are defined.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c577910-3ed8-407f-a9cb-6ce61e585a54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c577910-3ed8-407f-a9cb-6ce61e585a54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

