### PR TITLE
Move matchup list widget from sidebar to viewer page top

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@
 | `ChampionViewerWidget` | チャンピオン情報を表示するWebビューウィジェット |
 | `QrCodeOverlay` | WebビューにQRコードを重ねて表示するフローティングウィジェット |
 | `LCUConnectionStatusWidget` | LCU接続状態を表示するステータスウィジェット |
-| `MatchupListWidget` | マッチアップリストをサイドバーに表示するウィジェット |
+| `MatchupListWidget` | マッチアップリストをビューアページ上部に表示するウィジェット |
 | `NullWebView` | テスト/ヘッドレス環境用のWebEngineView代替 |
 
 ### 外部モジュール

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ CLOSE_BUTTON_GLYPH = "×"
 FEATURE_FLAG_DEFINITIONS: dict = {
     "matchup_list": {
         "label": "Matchup List",
-        "description": "Show a 5-row matchup list in the sidebar displaying ally vs enemy champion picks.",
+        "description": "Show a 5-row matchup list above the viewer toolbar displaying ally vs enemy champion picks.",
         "default": False,
     },
 }
@@ -1095,11 +1095,6 @@ class MainWindow(QMainWindow):
         sidebar_layout.setContentsMargins(0, 0, 0, 0)
         sidebar_layout.addWidget(self.sidebar)
 
-        # Matchup list (ally vs enemy, 5 rows) — controlled by feature flag
-        self.matchup_list_widget = self._create_matchup_list_widget()
-        sidebar_layout.addWidget(self.matchup_list_widget)
-        self.matchup_list_widget.setVisible(self.feature_flags.get("matchup_list", False))
-
         sidebar_layout.addWidget(self.connection_status_widget)
 
         # Create splitter for resizable sidebar
@@ -1175,6 +1170,11 @@ class MainWindow(QMainWindow):
         viewers_layout = QVBoxLayout(self.viewers_page)
         viewers_layout.setSpacing(0)
         viewers_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Matchup list (ally vs enemy, 5 rows) — controlled by feature flag
+        self.matchup_list_widget = self._create_matchup_list_widget()
+        self.matchup_list_widget.setVisible(self.feature_flags.get("matchup_list", False))
+        viewers_layout.addWidget(self.matchup_list_widget)
 
         # Top toolbar with add and close all buttons
         self.create_toolbar()


### PR DESCRIPTION
## Summary
Relocates the matchup list widget from the sidebar to the top of the viewers page, above the toolbar. This change improves the UI layout by placing the matchup list in a more prominent and contextually relevant location.

## Changes
- **Layout restructuring**: Moved `matchup_list_widget` initialization from `init_ui()` sidebar layout to `create_viewers_page()` viewers layout
- **Documentation update**: Updated architecture documentation to reflect that the matchup list is now displayed above the viewer toolbar instead of in the sidebar
- **Feature flag description**: Updated the feature flag description in `main.py` to accurately describe the new placement

## Implementation Details
- The widget is still controlled by the same `matchup_list` feature flag
- Visibility state is preserved and applied in the new location
- The widget is added to `viewers_layout` before the toolbar, ensuring it appears at the top of the viewers page
- No functional changes to the widget itself, only its positioning in the UI hierarchy

https://claude.ai/code/session_01W6rgew2cEnMJGDM6sfc6Jq