### PR TITLE
fix: ドラフトピック時のサイドバーアイコンクラッシュとClose All問題を修正

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -2209,11 +2209,14 @@ class MainWindow(QMainWindow):
         return suggestions
 
     def close_all_viewers(self):
-        """Close all viewer widgets"""
+        """Close all viewer widgets and pending picks"""
         # Create a copy of the list to avoid modification during iteration
         viewers_copy = self.viewers.copy()
         for viewer in viewers_copy:
             self.close_viewer(viewer)
+        # Also clear pending enemy picks from sidebar
+        self.pending_enemy_picks.clear()
+        self.update_viewers_list()
 
     def on_champion_detected(self, champion_name: str, lane: str):
         """Handle own champion detection — schedule build page opening."""

--- a/widgets/viewer_list_item.py
+++ b/widgets/viewer_list_item.py
@@ -5,6 +5,16 @@ from PyQt6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QPushButt
 from constants import get_ui_sizes
 
 
+def _safe_set_icon_pixmap(label: QLabel, pixmap: QPixmap, size: int):
+    """Set pixmap on a sidebar icon label, ignoring if the C++ object was deleted."""
+    try:
+        label.setPixmap(
+            pixmap.scaled(size, size, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+        )
+    except RuntimeError:
+        pass
+
+
 class ViewerListItemWidget(QWidget):
     """Custom widget for viewer list items showing champion icon, name and page type"""
 
@@ -164,9 +174,7 @@ class ViewerListItemWidget(QWidget):
         cache = self.parent_window._sidebar_image_cache
         pixmap = cache.get_image(
             url,
-            callback=lambda pm, lbl=self.icon_label: lbl.setPixmap(
-                pm.scaled(icon_s, icon_s, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
-            ),
+            callback=lambda pm, lbl=self.icon_label, s=icon_s: _safe_set_icon_pixmap(lbl, pm, s),
         )
         if pixmap:
             self.icon_label.setPixmap(
@@ -320,9 +328,7 @@ class PendingPickListItemWidget(QWidget):
         cache = self.parent_window._sidebar_image_cache
         pixmap = cache.get_image(
             url,
-            callback=lambda pm, lbl=self.icon_label: lbl.setPixmap(
-                pm.scaled(icon_s, icon_s, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
-            ),
+            callback=lambda pm, lbl=self.icon_label, s=icon_s: _safe_set_icon_pixmap(lbl, pm, s),
         )
         if pixmap:
             self.icon_label.setPixmap(


### PR DESCRIPTION
- PendingPickListItemWidget/ViewerListItemWidgetのアイコンコールバックに _safe_set_icon_pixmap()を追加し、Widget破棄後のRuntimeErrorを防ぐ (ドラフトピック時にupdate_viewers_list()が繰り返し呼ばれ、 破棄済みQLabelへsetPixmap()が呼ばれるクラッシュの修正)
- close_all_viewers()でpending_enemy_picksもクリアするよう修正